### PR TITLE
Add new command to create JSDoc comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Files are automatically rescanned when saved.
 
 -   Toggle terminal visibility = **Ctrl + '** (**Alt + '**)
 
+### JS Doc
+-   Insert JS Doc for function or class definition = **CMD + D** (**Ctrl + D**)
+
 ### Layouts
 Shortcuts to control the layout of the workspace
 -   **Ctrl + 1** = Sidebar + Editor + Terminal
@@ -114,6 +117,9 @@ Shortcuts to control the layout of the workspace
     ```
 
 ## Release Notes
+
+### 1.0.4
+-   Added command to insert JS Doc for a function or class definition.
 
 ### 1.0.3
 -   Search now includes files without need for @ at start of query.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The extension provides the following features:
     - Text search
     - Workspace layouts
 
+5. Command to create JSDoc comment for a function or class.<br>
+Press CMD+D when the cursor is on the definition line to create a JSDoc comment populated with the parameters.
+
 <br>
 The extension scans for definitions in the paths specified by the setting iqgeo-utils-vscode.searchPaths (see below).<br>
 Files are automatically rescanned when saved.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "publisher": "IQGeo",
     "license": "MIT",
     "repository": "https://github.com/IQGeo/utils-vscode",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "icon": "images/iqgeo_logo.png",
     "engines": {
         "vscode": "^1.81.0"
@@ -30,6 +30,10 @@
             {
                 "command": "iqgeo.goToDefinition",
                 "title": "IQGeo Go To Definition"
+            },
+            {
+                "command": "iqgeo.addJSDoc",
+                "title": "IQGeo Add JSDoc"
             },
             {
                 "command": "iqgeo.searchRoot",
@@ -199,6 +203,16 @@
                 "key": "cmd+r",
                 "command": "-jupyter.refreshDataViewer",
                 "when": "isWorkspaceTrusted && jupyter.dataViewerActive"
+            },
+
+            {
+                "command": "iqgeo.addJSDoc",
+                "key": "cmd+d"
+            },
+            {
+                "command": "iqgeo.addJSDoc",
+                "key": "ctrl+d",
+                "when": "!isMac"
             },
 
             {

--- a/src/iqgeo-js-search.js
+++ b/src/iqgeo-js-search.js
@@ -34,8 +34,11 @@ class IQGeoJSSearch {
         this.iqgeoVSCode = iqgeoVSCode;
     }
 
-    updateClasses(fileName) {
-        const fileLines = Utils.getFileLines(fileName);
+    updateClasses(fileName, fileLines = undefined) {
+        if (!fileLines) {
+            fileLines = Utils.getFileLines(fileName);
+        }
+
         const len = fileLines.length;
         const inWorkspace = this.iqgeoVSCode.isWorkspaceFile(fileName);
         let classFound = false; // debug flag

--- a/src/iqgeo-js-search.js
+++ b/src/iqgeo-js-search.js
@@ -13,6 +13,7 @@ const MIXIN_REG = /(\w+(Mixin)?)\s*=\s*{/;
 const EXPORT_MIXIN_REG = /^export\s+(?:(?:default|const)\s+)*(\w+(Mixin)?)\s*=\s*{/;
 const CLASS_ASSIGN_REG = /(?:^|\s+)Object\.assign\(.*?(\w+)\.prototype,\s*(\w+)\)/;
 const PROPERTY_REG = /^\s*#?(\w+):/;
+const SETTER_OR_GETTER_REG = /^\s*(?:(?:set|get)\s+)(\w+)\s*\(/;
 const FUNCTION_REG = /^\s*(?:async\s+|static\s+|#)?\*?(\w+)\s*\(([\w,\s={}\[\]'"]|\.{3})*?\)\s*{/;
 const FUNCTION_MULTI_LINE_REG = /^\s*(async\s*|static\s*|#)?\*?\w+\s*\(\s*$/;
 const CONST_FUNCTION_REG = /^const\s+(\w+)\s*=\s*(?:async\s+)?function\*?\s*\(/;
@@ -393,8 +394,12 @@ class IQGeoJSSearch {
     }
 
     _findPropertyDef(str) {
-        const match = str.match(PROPERTY_REG);
+        let match = str.match(PROPERTY_REG);
+        if (match) {
+            return match[1];
+        }
 
+        match = str.match(SETTER_OR_GETTER_REG);
         if (match) {
             return match[1];
         }

--- a/src/iqgeo-js-search.js
+++ b/src/iqgeo-js-search.js
@@ -38,6 +38,7 @@ class IQGeoJSSearch {
     updateClasses(fileName, fileLines = undefined) {
         if (!fileLines) {
             fileLines = Utils.getFileLines(fileName);
+            if (!fileLines) return;
         }
 
         const len = fileLines.length;

--- a/src/iqgeo-jsdoc.js
+++ b/src/iqgeo-jsdoc.js
@@ -1,0 +1,105 @@
+const vscode = require('vscode'); // eslint-disable-line
+const Utils = require('./utils');
+
+class IQGeoJSDoc {
+    constructor(iqgeoVSCode, context) {
+        this.iqgeoVSCode = iqgeoVSCode;
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand('iqgeo.addJSDoc', () => this._addJSDocTemplate())
+        );
+    }
+
+    async _addJSDocTemplate() {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) return;
+
+        const doc = editor.document;
+        if (doc.languageId !== 'javascript') return;
+
+        this.iqgeoVSCode.updateClassesForDoc(doc, true);
+
+        const sortedSymbols = this.iqgeoVSCode.getSymbolsForFile(doc.fileName);
+        const line = editor.selection.active.line;
+
+        const currentSym = sortedSymbols.find((sym) => {
+            const symLine = sym.location.range.start.line;
+            return symLine === line || symLine - 1 === line;
+        });
+        if (!currentSym) return;
+
+        const symLine = currentSym.location.range.start.line;
+        const kind = currentSym.kind;
+        let docLines;
+        let templateStr;
+
+        if (kind === vscode.SymbolKind.Class) {
+            docLines = Utils.getDocLines(doc);
+            const indent = docLines[symLine].match(/^\s*/)[0];
+            const className = currentSym._className;
+
+            templateStr = `\n${indent}/**\n${indent} * ${className}\n`;
+
+            for (const parentClass of this.iqgeoVSCode.getParents(className, 'javascript')) {
+                templateStr += `${indent} * @extends ${parentClass}\n`;
+            }
+
+            templateStr += `${indent} */`;
+        } else if ([vscode.SymbolKind.Function, vscode.SymbolKind.Method].includes(kind)) {
+            docLines = Utils.getDocLines(doc);
+            const params = this._getParamsForSymbol(currentSym, docLines);
+            const indent = docLines[symLine].match(/^\s*/)[0];
+
+            templateStr = `\n${indent}/**\n${indent} *\n`;
+
+            params.forEach((name) => {
+                templateStr += `${indent} * @param {} ${name} - \n`;
+            });
+
+            if (currentSym._methodName !== 'constructor()') {
+                templateStr += `${indent} * @return {}\n`;
+            }
+
+            templateStr += `${indent} */`;
+        }
+
+        if (templateStr) {
+            const edit = new vscode.WorkspaceEdit();
+            const col = docLines[symLine - 1].length;
+            const insertPos = new vscode.Position(symLine - 1, col);
+            edit.insert(doc.uri, insertPos, templateStr);
+            await vscode.workspace.applyEdit(edit);
+        }
+    }
+
+    _getParamsForSymbol(sym, fileLines) {
+        const symLine = sym.location.range.start.line;
+
+        const paramReg = /\(((\s*(\.\.\.)?(\{|\w+).*?,?)*)\)/;
+        const length = Math.min(symLine + 16, fileLines.length);
+        const paramNames = [];
+        let str = '';
+
+        for (let i = symLine; i < length; i++) {
+            str += fileLines[i];
+            const match = str.match(paramReg);
+            if (match) {
+                match[1].split(',').forEach((s) => {
+                    const name = s.split('=')[0].trim();
+                    if (name.startsWith('{')) {
+                        paramNames.push('{}');
+                    } else if (name.startsWith('...')) {
+                        paramNames.push(name.slice(3));
+                    } else if (name.length) {
+                        paramNames.push(name);
+                    }
+                });
+                break;
+            }
+        }
+
+        return paramNames;
+    }
+}
+
+module.exports = IQGeoJSDoc;

--- a/src/iqgeo-jsdoc.js
+++ b/src/iqgeo-jsdoc.js
@@ -56,7 +56,7 @@ class IQGeoJSDoc {
             const params = this._getParamsForSymbol(currentSym, docLines);
             const indent = docLines[symLine].match(/^\s*/)[0];
 
-            templateStr = `\n${indent}/**\n${indent} *\n`;
+            templateStr = `\n${indent}/**\n${indent} * \n`;
 
             params.forEach((name) => {
                 templateStr += `${indent} * @param {} ${name} - \n`;
@@ -70,11 +70,20 @@ class IQGeoJSDoc {
         }
 
         if (templateStr) {
+            // Insert the comment populated with params
             const edit = new vscode.WorkspaceEdit();
             const col = docLines[symLine - 1].length;
             const insertPos = new vscode.Position(symLine - 1, col);
             edit.insert(doc.uri, insertPos, templateStr);
             await vscode.workspace.applyEdit(edit);
+
+            // Move cursor to the first line in the comment
+            const newCol = doc.lineAt(symLine + 1).text.length;
+            const newPos = new vscode.Position(symLine + 1, newCol);
+            const newRange = new vscode.Range(newPos, newPos);
+            vscode.window.showTextDocument(doc.uri, {
+                selection: newRange,
+            });
         }
     }
 

--- a/src/iqgeo-python-search.js
+++ b/src/iqgeo-python-search.js
@@ -10,8 +10,11 @@ class IQGeoPythonSearch {
         this.iqgeoVSCode = iqgeoVSCode;
     }
 
-    updateClasses(fileName) {
-        const fileLines = Utils.getFileLines(fileName);
+    updateClasses(fileName, fileLines = undefined) {
+        if (!fileLines) {
+            fileLines = Utils.getFileLines(fileName);
+        }
+
         const len = fileLines.length;
         const inWorkspace = this.iqgeoVSCode.isWorkspaceFile(fileName);
         let classFound = false; // debug flag

--- a/src/iqgeo-python-search.js
+++ b/src/iqgeo-python-search.js
@@ -13,6 +13,7 @@ class IQGeoPythonSearch {
     updateClasses(fileName, fileLines = undefined) {
         if (!fileLines) {
             fileLines = Utils.getFileLines(fileName);
+            if (!fileLines) return;
         }
 
         const len = fileLines.length;

--- a/src/iqgeo-search.js
+++ b/src/iqgeo-search.js
@@ -17,7 +17,6 @@ class IQGeoSearch {
 
         this._symbolSelector = undefined;
         this._lastQuery = '';
-        this._lastGoToRange = undefined;
         this._viewColumn = undefined;
         this._sideBarVisible = false;
         this._fileIconConfig = undefined;
@@ -129,13 +128,12 @@ class IQGeoSearch {
                 }
                 this._lastQuery = newQuery;
             }
-        } else if (!Utils.rangesEqual(Utils.selectedRange(), this._lastGoToRange)) {
+        } else {
             const selection = Utils.selectedText();
             if (selection && selection !== '') {
                 newQuery = selection;
                 this._lastQuery = newQuery;
             }
-            this._lastGoToRange = undefined;
         }
 
         this._sideBarVisible = sideBarVisible;
@@ -275,22 +273,14 @@ class IQGeoSearch {
 
         for (let index = 0; index < symbolsLength; index++) {
             const sym = symbols[index];
+
+            const iconPath = this._getFileIcon(sym._fileName);
             let label;
-            let iconPath;
 
             if (sym.kind === vscode.SymbolKind.File) {
-                iconPath = this._getFileIcon(sym._fileName);
-                if (iconPath) {
-                    label = sym.name;
-                }
-            }
-
-            if (!label) {
-                const name =
-                    sym.kind === vscode.SymbolKind.File
-                        ? sym.name
-                        : sym.name.replace(/\./g, '\u2009.\u2009');
-
+                label = iconPath ? sym.name : `$(${sym._icon}) ${sym.name}`;
+            } else {
+                const name = sym.name.replace(/\./g, '\u2009.\u2009');
                 label = `$(${sym._icon}) ${name}`;
             }
 
@@ -323,37 +313,12 @@ class IQGeoSearch {
             preview = workbenchConfig.editor.enablePreviewFromCodeNavigation;
         }
 
-        this._lastGoToRange = symRange;
-
         vscode.window.showTextDocument(sym.location.uri, {
             selection: symRange,
             viewColumn,
             preview,
             preserveFocus,
         });
-    }
-
-    _getSymbolsForFile(fileName) {
-        const symbols = [];
-
-        for (const [className, classData] of this.iqgeoVSCode.allClasses()) {
-            if (classData.fileName === fileName) {
-                const classSym = this.iqgeoVSCode.getClassSymbol(className, classData);
-                symbols.push(classSym);
-
-                for (const [methodName, methodData] of Object.entries(classData.methods)) {
-                    const name = `${className}.${methodName}`;
-                    const sym = this.iqgeoVSCode.getMethodSymbol(name, methodData);
-                    symbols.push(sym);
-                }
-            }
-        }
-
-        symbols.sort((a, b) => {
-            return a.location.range.start.line - b.location.range.start.line;
-        });
-
-        return symbols;
     }
 
     _goToNextSymbol(next = true) {
@@ -367,7 +332,7 @@ class IQGeoSearch {
         if (editor) {
             const doc = editor.document;
             if (doc.languageId === 'javascript' || doc.languageId === 'python') {
-                const sortedSymbols = this._getSymbolsForFile(doc.fileName);
+                const sortedSymbols = this.iqgeoVSCode.getSymbolsForFile(doc.fileName);
                 const line = editor.selection.active.line;
                 let symLine;
                 let targetIndex;

--- a/src/iqgeo-search.js
+++ b/src/iqgeo-search.js
@@ -41,7 +41,10 @@ class IQGeoSearch {
         );
 
         context.subscriptions.push(
-            vscode.commands.registerCommand('iqgeo.searchEditor', () => this._runEditorSearch())
+            vscode.commands.registerCommand('iqgeo.searchEditor', () => {
+                const rootFolder = this.iqgeoVSCode.rootFolders[0];
+                this._runSearch(rootFolder, true);
+            })
         );
 
         context.subscriptions.push(
@@ -67,7 +70,7 @@ class IQGeoSearch {
         this._runSearch(workspaceFolder);
     }
 
-    _runSearch(folder) {
+    _runSearch(folder = undefined, inEditor = false) {
         let query = '';
 
         const editor = vscode.window.activeTextEditor;
@@ -80,29 +83,12 @@ class IQGeoSearch {
             }
         }
 
-        vscode.commands.executeCommand('workbench.action.findInFiles', {
+        const commandName = inEditor ? 'search.action.openEditor' : 'workbench.action.findInFiles';
+
+        vscode.commands.executeCommand(commandName, {
             query,
             filesToInclude: folder,
             filesToExclude: '*.txt, *.csv, *.svg, *.*_config, node_modules, bundles',
-        });
-    }
-
-    _runEditorSearch() {
-        let query = '';
-
-        const editor = vscode.window.activeTextEditor;
-        if (editor) {
-            query = Utils.selectedText();
-            if (!query) {
-                const doc = editor.document;
-                const pos = editor.selection.active;
-                query = Utils.currentWord(doc, pos);
-            }
-        }
-
-        vscode.commands.executeCommand('search.action.openEditor', {
-            query,
-            // filesToExclude: '*.txt, *.csv, *.svg, *.*_config, node_modules, bundles',
         });
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -135,12 +135,12 @@ function removeComments(str, inComment = false) {
 }
 
 function removeLineComment(str) {
-    let index = str.indexOf('//')
+    let index = str.indexOf('//');
     while (index > -1) {
         if (!withinString(str, index)) {
             return str.substring(0, index);
         }
-        index = str.indexOf('//', index + 2)
+        index = str.indexOf('//', index + 2);
     }
     return str;
 }


### PR DESCRIPTION
Added a new command to generate a JSDoc comment for a function or class definition.
The comment is populated with any parameters and defaults.
The cursor will be moved to the first line in the comment to allow co-pilot to 'help' with completion.
Updated JS search to find setters and getters.
The search results list will now always show the file icon (if possible) to distinguish between languages.
Updated version to 1.0.4