### PR TITLE
Add watch to restart Apache and Chrome debug session.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ Shortcuts to control the layout of the workspace
 
 ## Release Notes
 
+### 1.0.7
+-   Added automatic watch to restart apache or restart the active debug session.
+
 ### 1.0.6
 -   New command to update an IQGeo project based on https://github.com/IQGeo/utils-project-template from the options specified in the .iqgeorc.jsonc configuration file.
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ IQGeo development extension to support code navigation and additional linting in
 The extension provides the following features:
 
 1. An alternative definition search dialog that shows a preview of the highlighted result in an editor.<br>
-    The search supports JavaScript and Python and accepts these query formats:
+   The search supports JavaScript and Python and accepts these query formats:
     - \<method name\>
     - \<class name\>
     - \<class name\>.\<method name\>
-    - \<file name\>
+    - \<file name or path\>
 
 <img src="images/def_search_app.png" width="850"/>
 
@@ -22,24 +22,33 @@ The extension provides the following features:
 3. Linting for API usage and subclassing.
 
 4. Set of shortcuts for
+
     - Definition search
     - Code navigation
     - Text search
     - Workspace layouts
 
 5. Command to create JSDoc comment for a function or class.<br>
-Press CMD+D when the cursor is on the definition line to create a JSDoc comment populated with the parameters.
+   Press Ctrl+Shift+D when the cursor is on the definition line to create a JSDoc comment populated with the parameters. Any defaults will be included.
 
 6. Command to update an IQGeo project based on options in .iqgeorc.jsonc configuration file.<br>
-See https://github.com/IQGeo/utils-project-template for details.
+   See https://github.com/IQGeo/utils-project-template for details.
+
+7. File watch to restart the Apache server or a debug client when a Python or JavaScript file change respectively.<br>
+   This functionality is enabled when **iqgeo-utils-vscode.enableAutoRestart** is set to true.<br>
+   The extension uses one terminal to restart the Apache server and another to run a file watch. A Chrome debug session will be restarted when a JavaScript file is saved.<br>
+   The watch can be started using the command 'IQGeo Start Watch'.<br>
+   The delay between saving a JavaScript file and restarting a debug session (to allow the watch build to complete) can be configured using the setting **iqgeo-utils-vscode.restartDelay** (defaults to 1500ms).
 
 <br>
 The extension scans for definitions in the paths specified by the setting iqgeo-utils-vscode.searchPaths (see below).<br>
+The search path defaults to the workspace folder or /opt/iqgeo/platform/WebApps/myworldapp when inside a dev container.<br>
 Files are automatically rescanned when saved.
 
 ## Usage
 
 ### Definition Search
+
 -   Search Definitions = **CMD + T** (**Ctrl + T**).<br>
     The search supports \<method name\> or \<class name\> or \<class\>.\<method\><br>
     Use \<class name\>. to list all functions for a class.<br>
@@ -53,6 +62,7 @@ Files are automatically rescanned when saved.
     (e.g. after changing branch)
 
 ### Text Search
+
 -   Search in the root folder = **CMD + G** (**Ctrl + G**)
 
 -   Search in the workspace (repository) folder = **CMD + R** (**Ctrl + R**)
@@ -60,6 +70,7 @@ Files are automatically rescanned when saved.
 -   Open Editor Search with current selection or word = **Ctrl + G** (**Alt + G**)
 
 ### Navigation
+
 -   Go to Definition = **CMD + .** (**Alt + .**)
 
 -   Go Back = **Ctrl + CMD + Left** (**Alt + Left**)
@@ -69,7 +80,6 @@ Files are automatically rescanned when saved.
 -   Peek Definition = **Ctrl + .**
 
 -   Go to References = **CMD + ,** (**Alt + ,**)
-
 
 <br>
 
@@ -86,10 +96,13 @@ Files are automatically rescanned when saved.
 -   Toggle terminal visibility = **Ctrl + '** (**Alt + '**)
 
 ### JSDoc
+
 -   Insert JSDoc for function or class definition = **Ctrl + Shift + D**
 
 ### Layouts
+
 Shortcuts to control the layout of the workspace
+
 -   **Ctrl + 1** = Sidebar + Editor + Terminal
 -   **Ctrl + 2** = Editor + Terminal
 -   **Ctrl + 3** = Sidebar + Editor
@@ -121,30 +134,50 @@ Shortcuts to control the layout of the workspace
     ```json
     "iqgeo-utils-vscode.enableLayouts": true
     ```
+-   Enable auto restart of Apache and Chrome debug session. (Default value is false)
+    ```json
+    "iqgeo-utils-vscode.enableAutoRestart": false
+    ```
+-   Command to watch for changes in the workspace. (Defaults to myw_product watch)
+    ```json
+    "iqgeo-utils-vscode.watchCommand": "myw_product watch applications_dev --debug"
+    ```
+-   Delay time in ms between a file change and restarting a Chrome debug session. (Defaults to 1500)
+    ```json
+    "iqgeo-utils-vscode.restartDelay": 1500
+    ```
 
 ## Release Notes
 
 ### 1.0.7
--   Added automatic watch to restart apache or restart the active debug session.
+
+-   Added automatic watch to restart Apache and the active Chrome debug session.
 
 ### 1.0.6
+
 -   New command to update an IQGeo project based on https://github.com/IQGeo/utils-project-template from the options specified in the .iqgeorc.jsonc configuration file.
 
 ### 1.0.5
+
 -   Update shortcut for JSDoc command.
 
 ### 1.0.4
+
 -   Added command to insert JSDoc for a function or class definition.
 
 ### 1.0.3
+
 -   Search now includes files without need for @ at start of query.
 -   Improved file search.
 
 ### 1.0.2
+
 -   Add workspace layout shortcuts.
 
 ### 1.0.1
+
 -   Update readme images and fix license date.
 
 ### 1.0.0
+
 -   Initial release of iqgeo-utils-vscode to support code navigation and linting.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The extension provides the following features:
 6. Command to update an IQGeo project based on options in .iqgeorc.jsonc configuration file.<br>
    See https://github.com/IQGeo/utils-project-template for details.
 
-7. File watch to restart the Apache server or a debug client when a Python or JavaScript file change respectively.<br>
+7. File watch to restart Python or browser debug session when a Python or JavaScript file change respectively.<br>
    This functionality is enabled when **iqgeo-utils-vscode.enableAutoRestart** is set to true.<br>
-   The extension uses one terminal to restart the Apache server and another to run a file watch. A Chrome debug session will be restarted when a JavaScript file is saved.<br>
+   The extension uses one terminal to restart the Python environment and another to run a Javascript file watch. A browser debug session (if active) will be restarted when a JavaScript file is saved.<br>
    The watch can be started using the command 'IQGeo Start Watch'.<br>
    The delay between saving a JavaScript file and restarting a debug session (to allow the watch build to complete) can be configured using the setting **iqgeo-utils-vscode.restartDelay** (defaults to 1500ms).
 
@@ -134,7 +134,7 @@ Shortcuts to control the layout of the workspace
     ```json
     "iqgeo-utils-vscode.enableLayouts": true
     ```
--   Enable auto restart of Apache and Chrome debug session. (Default value is false)
+-   Enable auto restart of Python and browser debug session. (Default value is false)
     ```json
     "iqgeo-utils-vscode.enableAutoRestart": false
     ```
@@ -142,7 +142,7 @@ Shortcuts to control the layout of the workspace
     ```json
     "iqgeo-utils-vscode.watchCommand": "myw_product watch applications_dev --debug"
     ```
--   Delay time in ms between a file change and restarting a Chrome debug session. (Defaults to 1500)
+-   Delay time in ms between a file change and restarting a browser debug session. (Defaults to 1500)
     ```json
     "iqgeo-utils-vscode.restartDelay": 1500
     ```
@@ -151,7 +151,7 @@ Shortcuts to control the layout of the workspace
 
 ### 1.0.7
 
--   Added automatic watch to restart Apache and the active Chrome debug session.
+-   Added automatic watch to restart Python and the active browser debug session.
 
 ### 1.0.6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "iqgeo-utils-vscode",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "iqgeo-utils-vscode",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "license": "MIT",
             "dependencies": {
                 "findit": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -208,7 +208,6 @@
                 "command": "iqgeo.addJSDoc",
                 "key": "ctrl+shift+d"
             },
-
             {
                 "command": "iqgeo.goToPreviousSymbol",
                 "key": "ctrl+pageup"
@@ -394,8 +393,8 @@
                 },
                 "iqgeo-utils-vscode.enableAutoRestart": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Enable auto restart of Apache and Client."
+                    "default": false,
+                    "description": "Enable auto restart of Apache and Chrome debug session."
                 },
                 "iqgeo-utils-vscode.watchCommand": {
                     "type": "string",
@@ -404,7 +403,7 @@
                 "iqgeo-utils-vscode.restartDelay": {
                     "type": "integer",
                     "default": 1500,
-                    "description": "Delay time in ms between a file change and restarting a client debug session."
+                    "description": "Delay time in ms between a file change and restarting a Chrome debug session."
                 },
                 "iqgeo-utils-vscode.resizeTerminal": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "publisher": "IQGeo",
     "license": "MIT",
     "repository": "https://github.com/IQGeo/utils-vscode",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "icon": "images/iqgeo_logo.png",
     "engines": {
         "vscode": "^1.81.0"
@@ -58,6 +58,10 @@
             {
                 "command": "iqgeo.updateProject",
                 "title": "IQGeo Update Project from .iqgeorc.jsonc"
+            },
+            {
+                "command": "iqgeo.startWatch",
+                "title": "IQGeo Start Watch"
             }
         ],
         "keybindings": [
@@ -387,6 +391,20 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable workspace layout shortcuts."
+                },
+                "iqgeo-utils-vscode.enableAutoRestart": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable auto restart of Apache and Client."
+                },
+                "iqgeo-utils-vscode.watchCommand": {
+                    "type": "string",
+                    "description": "Command to watch for changes in the workspace. Defaults to myw_product watch"
+                },
+                "iqgeo-utils-vscode.restartDelay": {
+                    "type": "integer",
+                    "default": 1500,
+                    "description": "Delay time in ms between a file change and restarting a client debug session."
                 },
                 "iqgeo-utils-vscode.resizeTerminal": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -394,7 +394,7 @@
                 "iqgeo-utils-vscode.enableAutoRestart": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enable auto restart of Apache and Chrome debug session."
+                    "description": "Enable auto restart of Python and browser debug session."
                 },
                 "iqgeo-utils-vscode.watchCommand": {
                     "type": "string",
@@ -403,7 +403,7 @@
                 "iqgeo-utils-vscode.restartDelay": {
                     "type": "integer",
                     "default": 1500,
-                    "description": "Delay time in ms between a file change and restarting a Chrome debug session."
+                    "description": "Delay time in ms between a file change and restarting a browser debug session."
                 },
                 "iqgeo-utils-vscode.resizeTerminal": {
                     "type": "boolean",

--- a/src/iqgeo-project-update.js
+++ b/src/iqgeo-project-update.js
@@ -131,8 +131,10 @@ const fileModifications = {
  * Project structure should as per https://github.com/IQGeo/utils-project-template with a .iqgeorc.jsonc configuration file
  */
 class IQGeoProjectUpdate {
-    constructor(iqgeoVSCode) {
-        this.iqgeoVSCode = iqgeoVSCode;
+    constructor(context) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand('iqgeo.updateProject', () => this.update())
+        );
     }
 
     /**
@@ -207,24 +209,22 @@ function fileUpdater(root, config) {
     };
 }
 
-
-
-
 function initDbModifier(config, content) {
-    const { modules }= config;
+    const { modules } = config;
     const section1 = modules
-        .filter(({ version, dbInit = !!version }) => dbInit )
-        .map(({ name, schemaGrep=name }) => `if ! myw_db $MYW_DB_NAME list versions | grep ${schemaGrep}; then myw_db $MYW_DB_NAME install ${name}; fi`)
+        .filter(({ version, dbInit = !!version }) => dbInit)
+        .map(
+            ({ name, schemaGrep = name }) =>
+                `if ! myw_db $MYW_DB_NAME list versions | grep ${schemaGrep}; then myw_db $MYW_DB_NAME install ${name}; fi`
+        )
         .join('\n');
     content = content.replace(
         /(# START SECTION db init.*)[\s\S]*?(# END SECTION)/,
         `$1\n${section1}\n$2`
     );
 
-    return content
+    return content;
 }
-
-
 
 function replaceModuleInjection(content, modules, isDevEnv = false) {
     const isFromInjectorFn = ({ version, devSrc }) => version && !devSrc;

--- a/src/iqgeo-vscode.js
+++ b/src/iqgeo-vscode.js
@@ -866,7 +866,7 @@ class IQGeoVSCode {
 
                 finder.on('file', (file) => {
                     const parts = path.basename(file).split('.');
-                    if (parts[0] !== '__init__') {
+                    if (parts[0] !== '__init__' && !file.endsWith('.bundle.js')) {
                         const ext = parts[parts.length - 1];
                         for (const config of this._languageConfig) {
                             if (config.extension === ext) {

--- a/src/iqgeo-watch.js
+++ b/src/iqgeo-watch.js
@@ -27,10 +27,10 @@ class IQGeoWatch {
         });
 
         vscode.window.onDidCloseTerminal((t) => {
-            if (t === this.watchTerminal) {
-                this.watchTerminal = undefined;
-            } else if (t === this.apacheTerminal) {
-                this.apacheTerminal = undefined;
+            if (t === this.jsTerminal) {
+                this.jsTerminal = undefined;
+            } else if (t === this.pythonTerminal) {
+                this.pythonTerminal = undefined;
             }
         });
     }
@@ -44,7 +44,7 @@ class IQGeoWatch {
 
         const workspaceFolder = this.iqgeoVSCode.getWorkspaceFolder();
 
-        if (!this._hasWatchTerminal()) {
+        if (!this._hasJSTerminal()) {
             let commandText = vscode.workspace.getConfiguration('iqgeo-utils-vscode').watchCommand;
 
             if (!commandText) {
@@ -56,36 +56,36 @@ class IQGeoWatch {
                     : 'myw_product watch applications_dev --debug';
             }
 
-            this.watchTerminal = vscode.window.createTerminal({
-                name: 'IQGeo Watch',
+            this.jsTerminal = vscode.window.createTerminal({
+                name: 'JS Watch',
                 cwd: workspaceFolder,
             });
-            this.watchTerminal.sendText(commandText, true);
+            this.jsTerminal.sendText(commandText, true);
         }
 
         if (
-            !this._hasApacheTerminal() &&
+            !this._hasPythonTerminal() &&
             fs.existsSync('/opt/iqgeo/platform/WebApps/myworldapp.wsgi')
         ) {
-            this.apacheTerminal = vscode.window.createTerminal({
-                name: 'Apache Restart',
+            this.pythonTerminal = vscode.window.createTerminal({
+                name: 'Python Restart',
                 cwd: workspaceFolder,
             });
         }
     }
 
     /**
-     * Closes the watch terminal and the apache terminal if they are running.
+     * Closes the JS watch terminal and the Python terminal if they are running.
      * @return {undefined}
      */
     stop() {
-        if (this._hasWatchTerminal()) {
-            this.watchTerminal.dispose();
-            this.watchTerminal = undefined;
+        if (this._hasJSTerminal()) {
+            this.jsTerminal.dispose();
+            this.jsTerminal = undefined;
         }
-        if (this._hasApacheTerminal()) {
-            this.apacheTerminal.dispose();
-            this.apacheTerminal = undefined;
+        if (this._hasPythonTerminal()) {
+            this.pythonTerminal.dispose();
+            this.pythonTerminal = undefined;
         }
     }
 
@@ -96,7 +96,7 @@ class IQGeoWatch {
 
         if (ext === '.js') {
             if (
-                this._hasWatchTerminal() &&
+                this._hasJSTerminal() &&
                 vscode.debug.activeDebugSession &&
                 CLIENT_DEBUG_TYPES.includes(vscode.debug.activeDebugSession.type)
             ) {
@@ -107,26 +107,26 @@ class IQGeoWatch {
             }
         } else if (
             ext === '.py' &&
-            this._hasApacheTerminal() &&
+            this._hasPythonTerminal() &&
             fs.existsSync('/opt/iqgeo/platform/WebApps/myworldapp.wsgi')
         ) {
             // 'apachectl -k restart'
-            this.apacheTerminal.sendText('touch /opt/iqgeo/platform/WebApps/myworldapp.wsgi', true);
+            this.pythonTerminal.sendText('touch /opt/iqgeo/platform/WebApps/myworldapp.wsgi', true);
         }
     }
 
-    _hasWatchTerminal() {
-        if (this.watchTerminal && this.watchTerminal.exitStatus !== undefined) {
-            this.watchTerminal = undefined;
+    _hasJSTerminal() {
+        if (this.jsTerminal && this.jsTerminal.exitStatus !== undefined) {
+            this.jsTerminal = undefined;
         }
-        return !!this.watchTerminal;
+        return !!this.jsTerminal;
     }
 
-    _hasApacheTerminal() {
-        if (this.apacheTerminal && this.apacheTerminal.exitStatus !== undefined) {
-            this.apacheTerminal = undefined;
+    _hasPythonTerminal() {
+        if (this.pythonTerminal && this.pythonTerminal.exitStatus !== undefined) {
+            this.pythonTerminal = undefined;
         }
-        return !!this.apacheTerminal;
+        return !!this.pythonTerminal;
     }
 }
 

--- a/src/iqgeo-watch.js
+++ b/src/iqgeo-watch.js
@@ -1,0 +1,126 @@
+const vscode = require('vscode'); // eslint-disable-line
+const fs = require('fs');
+const path = require('path');
+const Utils = require('./utils');
+
+const CLIENT_DEBUG_TYPES = [
+    'chrome',
+    'pwa-chrome',
+    'msedge',
+    'pwa-msedge',
+    'vscode-edge-devtools.debug',
+];
+
+/**
+ * The IQGeoWatch class is responsible for starting the webpack watch and restarting the client debug session when a file is saved.
+ */
+class IQGeoWatch {
+    constructor(iqgeoVSCode, context) {
+        this.iqgeoVSCode = iqgeoVSCode;
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand('iqgeo.startWatch', () => this.start())
+        );
+
+        vscode.workspace.onDidSaveTextDocument((doc) => {
+            this._restartApp(doc);
+        });
+
+        vscode.window.onDidCloseTerminal((t) => {
+            if (t === this.watchTerminal) {
+                this.watchTerminal = undefined;
+            } else if (t === this.apacheTerminal) {
+                this.apacheTerminal = undefined;
+            }
+        });
+    }
+
+    /**
+     * Creates the watch terminal and starts the webpack build watch.
+     * @return {undefined}
+     */
+    start() {
+        if (!vscode.workspace.getConfiguration('iqgeo-utils-vscode').enableAutoRestart) return;
+
+        const workspaceFolder = this.iqgeoVSCode.getWorkspaceFolder();
+
+        if (!this._hasWatchTerminal()) {
+            let commandText = vscode.workspace.getConfiguration('iqgeo-utils-vscode').watchCommand;
+
+            if (!commandText) {
+                const isPlatform = fs.existsSync(`${workspaceFolder}/WebApps/myworldapp`);
+                // 'export BUILD=applications,config,native,tests; cd /opt/iqgeo/platform/WebApps/myworldapp; npx webpack --config webpack.config.js --watch'
+                // `export BUILD=base,config,client,applications,native,tests; cd ${workspaceFolder}/WebApps/myworldapp; npx webpack --config webpack.config.js --watch`
+                commandText = isPlatform
+                    ? 'myw_product watch core_dev --debug'
+                    : 'myw_product watch applications_dev --debug';
+            }
+
+            this.watchTerminal = vscode.window.createTerminal({
+                name: 'IQGeo Watch',
+                cwd: workspaceFolder,
+            });
+            this.watchTerminal.sendText(commandText, true);
+        }
+
+        if (!this._hasApacheTerminal()) {
+            this.apacheTerminal = vscode.window.createTerminal({
+                name: 'Apache Restart',
+                cwd: workspaceFolder,
+            });
+        }
+    }
+
+    /**
+     * Closes the watch terminal and the apache terminal if they are running.
+     * @return {undefined}
+     */
+    stop() {
+        if (this._hasWatchTerminal()) {
+            this.watchTerminal.dispose();
+            this.watchTerminal = undefined;
+        }
+        if (this._hasApacheTerminal()) {
+            this.apacheTerminal.dispose();
+            this.apacheTerminal = undefined;
+        }
+    }
+
+    async _restartApp(doc) {
+        if (!vscode.workspace.getConfiguration('iqgeo-utils-vscode').enableAutoRestart) return;
+
+        const ext = path.extname(doc.fileName);
+
+        if (ext === '.js') {
+            if (
+                this._hasWatchTerminal() &&
+                vscode.debug.activeDebugSession &&
+                CLIENT_DEBUG_TYPES.includes(vscode.debug.activeDebugSession.type)
+            ) {
+                const restartDelay =
+                    vscode.workspace.getConfiguration('iqgeo-utils-vscode').restartDelay ?? 1500;
+                await Utils.wait(restartDelay);
+                await vscode.commands.executeCommand('workbench.action.debug.restart');
+            }
+        } else if (ext === '.py' && this._hasApacheTerminal()) {
+            // 'touch /opt/iqgeo/platform/WebApps/myworldapp.wsgi'
+            this.apacheTerminal.sendText('apachectl -k restart', true);
+        }
+    }
+
+    _hasWatchTerminal() {
+        if (this.watchTerminal && this.watchTerminal.exitStatus !== undefined) {
+            this.watchTerminal = undefined;
+        }
+        return !!this.watchTerminal;
+    }
+
+    _hasApacheTerminal() {
+        if (this.apacheTerminal && this.apacheTerminal.exitStatus !== undefined) {
+            this.apacheTerminal = undefined;
+        }
+        return !!this.apacheTerminal;
+    }
+}
+
+module.exports = IQGeoWatch;

--- a/src/iqgeo-watch.js
+++ b/src/iqgeo-watch.js
@@ -63,7 +63,10 @@ class IQGeoWatch {
             this.watchTerminal.sendText(commandText, true);
         }
 
-        if (!this._hasApacheTerminal()) {
+        if (
+            !this._hasApacheTerminal() &&
+            fs.existsSync('/opt/iqgeo/platform/WebApps/myworldapp.wsgi')
+        ) {
             this.apacheTerminal = vscode.window.createTerminal({
                 name: 'Apache Restart',
                 cwd: workspaceFolder,
@@ -102,9 +105,13 @@ class IQGeoWatch {
                 await Utils.wait(restartDelay);
                 await vscode.commands.executeCommand('workbench.action.debug.restart');
             }
-        } else if (ext === '.py' && this._hasApacheTerminal()) {
-            // 'touch /opt/iqgeo/platform/WebApps/myworldapp.wsgi'
-            this.apacheTerminal.sendText('apachectl -k restart', true);
+        } else if (
+            ext === '.py' &&
+            this._hasApacheTerminal() &&
+            fs.existsSync('/opt/iqgeo/platform/WebApps/myworldapp.wsgi')
+        ) {
+            // 'apachectl -k restart'
+            this.apacheTerminal.sendText('touch /opt/iqgeo/platform/WebApps/myworldapp.wsgi', true);
         }
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,21 @@
 const IQGeoVSCode = require("./iqgeo-vscode");
 const IQGeoLayout = require("./iqgeo-layout");
+const IQGeoProjectUpdate = require('./iqgeo-project-update');
+
+let iqgeoVSCode;
 
 function activate(context) {
-    const iqgeoVSCode = new IQGeoVSCode(context);
+    iqgeoVSCode = new IQGeoVSCode(context);
     new IQGeoLayout(context);
+    new IQGeoProjectUpdate(context);
     iqgeoVSCode.onActivation();
 }
 
+function deactivate() {
+    iqgeoVSCode.onDeactivation();
+}
+
 module.exports = {
-    activate
+    activate,
+    deactivate
 };

--- a/src/search/iqgeo-js-search.js
+++ b/src/search/iqgeo-js-search.js
@@ -1,5 +1,5 @@
 const vscode = require('vscode'); // eslint-disable-line
-const Utils = require('./utils');
+const Utils = require('../utils');
 
 const EXTEND_REG = /(\w+)\.extend\s*\(\s*['"](\w+)['"]/;
 const EXTEND_MULTI_REG = /(\w+)\.extend\s*\(\s*$/;

--- a/src/search/iqgeo-python-search.js
+++ b/src/search/iqgeo-python-search.js
@@ -1,5 +1,5 @@
 const vscode = require('vscode'); // eslint-disable-line
-const Utils = require('./utils');
+const Utils = require('../utils');
 
 const PYTHON_CLASS_REG = /^\s*class\s+(\w+)(?:\(((?:\w+,?\s*)*?)\))?:/;
 const PYTHON_DEF_REG = /^\s+def\s+(\w+)\(.*?\):/;

--- a/src/search/iqgeo-search.js
+++ b/src/search/iqgeo-search.js
@@ -1,7 +1,7 @@
 const vscode = require('vscode'); // eslint-disable-line
 const fs = require('fs');
 const path = require('path');
-const Utils = require('./utils');
+const Utils = require('../utils');
 
 const LANGUAGE_MAP = {
     'js': 'javascript',

--- a/src/utils.js
+++ b/src/utils.js
@@ -261,6 +261,10 @@ function debounce(callback, wait) {
     };
 }
 
+function wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 module.exports = {
     getFileLines,
     getDocLines,
@@ -277,4 +281,5 @@ module.exports = {
     selectedText,
     matchMultiLine,
     debounce,
+    wait,
 };


### PR DESCRIPTION
The extension can now start a JS watch and restart a Chrome debug session (if active) and restart Apache.
Added setting iqgeo-utils-vscode.enableAutoRestart (default to false) to control this functionality.
Updated the readme with these changes and moved the version to 1.0.7