### PR TITLE
Update Python search to handle type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ Shortcuts to control the layout of the workspace
     ```json
     "iqgeo-utils-vscode.enableLinting": true
     ```
+-   Defines the linting severity for missing API comments. Can be one of "Error", "Warning", "Information" or "Hint". (Default value is "Error")
+    ```json
+    "iqgeo-utils-vscode.apiLintingSeverity": "Error"
+    ```
 -   Defines whether workspace layout shortcuts are enabled. (Default value is true)
     ```json
     "iqgeo-utils-vscode.enableLayouts": true
@@ -149,6 +153,11 @@ Shortcuts to control the layout of the workspace
     ```
 
 ## Release Notes
+
+### 1.0.9
+
+-   Updated Python search for type hints.
+-   Added config for API linting severity.
 
 ### 1.0.8
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "iqgeo-utils-vscode",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "iqgeo-utils-vscode",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "license": "MIT",
             "dependencies": {
                 "findit": "^2.0.0",
@@ -17,15 +17,6 @@
             },
             "engines": {
                 "vscode": "^1.81.0"
-            }
-        },
-        "node_modules/@aashutoshrathi/word-wrap": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -897,17 +888,17 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "dependencies": {
-                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0"
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -1205,6 +1196,15 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -378,6 +378,12 @@
                 },
                 "iqgeo-utils-vscode.apiLintingSeverity": {
                     "type": "string",
+                    "enum": [
+                        "Error",
+                        "Warning",
+                        "Information",
+                        "Hint"
+                    ],
                     "default": "Error",
                     "description": "Linting severity for missing API comments."
                 },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "publisher": "IQGeo",
     "license": "MIT",
     "repository": "https://github.com/IQGeo/utils-vscode",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "icon": "images/iqgeo_logo.png",
     "engines": {
         "vscode": "^1.81.0"
@@ -375,6 +375,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable API and subclassing linting."
+                },
+                "iqgeo-utils-vscode.apiLintingSeverity": {
+                    "type": "string",
+                    "default": "Error",
+                    "description": "Linting severity for missing API comments."
                 },
                 "iqgeo-utils-vscode.enableMethodCheck": {
                     "type": "boolean",

--- a/src/search/iqgeo-js-search.js
+++ b/src/search/iqgeo-js-search.js
@@ -2,9 +2,9 @@ const vscode = require('vscode'); // eslint-disable-line
 const Utils = require('../utils');
 
 const EXTEND_REG = /(\w+)\.extend\s*\(\s*['"](\w+)['"]/;
-const EXTEND_MULTI_REG = /(\w+)\.extend\s*\(\s*$/;
+const EXTEND_MULTI_LINE_REG = /(\w+)\.extend\s*\(\s*$/;
 const EXTEND_NO_STRING_REG = /(\w+)\s*=.*?(\w+)\.extend\s*\((\s*['"]([\w\s]+)['"]\s*,)?\s*{/;
-const EXTEND_NO_STRING_MULTI_REG = /(\w+)\s*=.*?(\w+)\.extend\s*\(\s*$/;
+const EXTEND_NO_STRING_MULTI_LINE_REG = /(\w+)\s*=.*?(\w+)\.extend\s*\(\s*$/;
 const CLASS_REG = /^\s*(?:export\s+)?(?:default\s+)?class\s+(\w+)\s+(?:extends)?.*?(\w+)?\s*{/;
 const NAMESPACE_CLASS_REG = /(?:\w+)\s*=\s*class\s+(\w+)\s+(?:extends)?.*?(\w+)?\s*\)?\s*{/;
 const NAMESPACE_CLASS_MULTI_LINE_REG = /(?:\w+)\s*=\s*class\s+(\w+)\s+(?:extends)\s*\(?/;
@@ -280,7 +280,7 @@ class IQGeoJSSearch {
             return { class: match[1], line, index };
         }
 
-        match = Utils.matchMultiLine(str, line, fileLines, EXTEND_MULTI_REG, EXTEND_REG);
+        match = Utils.matchMultiLine(str, line, fileLines, EXTEND_MULTI_LINE_REG, EXTEND_REG);
         if (match) {
             const index = str.indexOf(match[2]) + match[2].length;
             return {
@@ -295,7 +295,7 @@ class IQGeoJSSearch {
             str,
             line,
             fileLines,
-            EXTEND_NO_STRING_MULTI_REG,
+            EXTEND_NO_STRING_MULTI_LINE_REG,
             EXTEND_NO_STRING_REG
         );
         if (match) {


### PR DESCRIPTION
Update Python search to handle type hints.
Fixed searching for multi line definitions in Python.
Added configuration setting for severity of API linting (missing public class and method comments).
Updated version to 1.0.9