### PR TITLE
Convert CJS to ESM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,26 +1,20 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "commonjs": true,
-        "es2021": true
+    env: {
+        es2021: true,
+        node: true,
     },
-    "extends": "eslint:recommended",
-    "overrides": [
+    extends: 'eslint:recommended',
+    overrides: [
         {
-            "env": {
-                "node": true
+            files: ['.eslintrc.{js,cjs}'],
+            parserOptions: {
+                sourceType: 'commonjs',
             },
-            "files": [
-                ".eslintrc.{js,cjs}"
-            ],
-            "parserOptions": {
-                "sourceType": "script"
-            }
-        }
+        },
     ],
-    "parserOptions": {
-        "ecmaVersion": "latest"
+    parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
     },
-    "rules": {
-    }
-}
+    rules: {},
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.vsix
+dist

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,16 +5,12 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ],
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "name": "Launch Extension",
-            "outFiles": [
-                "${workspaceFolder}/out/**/*.js"
-            ],
+            "outFiles": ["${workspaceFolder}/dist/main.cjs"],
             "request": "launch",
-            "type": "extensionHost"
+            "type": "extensionHost",
+            "preLaunchTask": "vscode:prepublish"
         }
-
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "vscode:prepublish",
+            "type": "shell",
+            "command": "npm",
+            "args": ["run", "vscode:prepublish"]
+        }
+    ]
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,2 +1,4 @@
 .vscode/**
 .gitignore
+node_modules/
+scripts/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,379 @@
                 "jsonc": "^2.0.0"
             },
             "devDependencies": {
+                "esbuild": "^0.21.3",
                 "eslint": "^8.51.0"
             },
             "engines": {
                 "vscode": "^1.81.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.3.tgz",
+            "integrity": "sha512-yTgnwQpFVYfvvo4SvRFB0SwrW8YjOxEoT7wfMT7Ol5v7v5LDNvSGo67aExmxOb87nQNeWPVvaGBNfQ7BXcrZ9w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.3.tgz",
+            "integrity": "sha512-bviJOLMgurLJtF1/mAoJLxDZDL6oU5/ztMHnJQRejbJrSc9FFu0QoUoFhvi6qSKJEw9y5oGyvr9fuDtzJ30rNQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.3.tgz",
+            "integrity": "sha512-c+ty9necz3zB1Y+d/N+mC6KVVkGUUOcm4ZmT5i/Fk5arOaY3i6CA3P5wo/7+XzV8cb4GrI/Zjp8NuOQ9Lfsosw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.3.tgz",
+            "integrity": "sha512-JReHfYCRK3FVX4Ra+y5EBH1b9e16TV2OxrPAvzMsGeES0X2Ndm9ImQRI4Ket757vhc5XBOuGperw63upesclRw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.3.tgz",
+            "integrity": "sha512-U3fuQ0xNiAkXOmQ6w5dKpEvXQRSpHOnbw7gEfHCRXPeTKW9sBzVck6C5Yneb8LfJm0l6le4NQfkNPnWMSlTFUQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.3.tgz",
+            "integrity": "sha512-3m1CEB7F07s19wmaMNI2KANLcnaqryJxO1fXHUV5j1rWn+wMxdUYoPyO2TnAbfRZdi7ADRwJClmOwgT13qlP3Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.3.tgz",
+            "integrity": "sha512-fsNAAl5pU6wmKHq91cHWQT0Fz0vtyE1JauMzKotrwqIKAswwP5cpHUCxZNSTuA/JlqtScq20/5KZ+TxQdovU/g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.3.tgz",
+            "integrity": "sha512-tci+UJ4zP5EGF4rp8XlZIdq1q1a/1h9XuronfxTMCNBslpCtmk97Q/5qqy1Mu4zIc0yswN/yP/BLX+NTUC1bXA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.3.tgz",
+            "integrity": "sha512-f6kz2QpSuyHHg01cDawj0vkyMwuIvN62UAguQfnNVzbge2uWLhA7TCXOn83DT0ZvyJmBI943MItgTovUob36SQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.3.tgz",
+            "integrity": "sha512-vvG6R5g5ieB4eCJBQevyDMb31LMHthLpXTc2IGkFnPWS/GzIFDnaYFp558O+XybTmYrVjxnryru7QRleJvmZ6Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.3.tgz",
+            "integrity": "sha512-HjCWhH7K96Na+66TacDLJmOI9R8iDWDDiqe17C7znGvvE4sW1ECt9ly0AJ3dJH62jHyVqW9xpxZEU1jKdt+29A==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.3.tgz",
+            "integrity": "sha512-BGpimEccmHBZRcAhdlRIxMp7x9PyJxUtj7apL2IuoG9VxvU/l/v1z015nFs7Si7tXUwEsvjc1rOJdZCn4QTU+Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.3.tgz",
+            "integrity": "sha512-5rMOWkp7FQGtAH3QJddP4w3s47iT20hwftqdm7b+loe95o8JU8ro3qZbhgMRy0VuFU0DizymF1pBKkn3YHWtsw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.3.tgz",
+            "integrity": "sha512-h0zj1ldel89V5sjPLo5H1SyMzp4VrgN1tPkN29TmjvO1/r0MuMRwJxL8QY05SmfsZRs6TF0c/IDH3u7XYYmbAg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.3.tgz",
+            "integrity": "sha512-dkAKcTsTJ+CRX6bnO17qDJbLoW37npd5gSNtSzjYQr0svghLJYGYB0NF1SNcU1vDcjXLYS5pO4qOW4YbFama4A==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.3.tgz",
+            "integrity": "sha512-vnD1YUkovEdnZWEuMmy2X2JmzsHQqPpZElXx6dxENcIwTu+Cu5ERax6+Ke1QsE814Zf3c6rxCfwQdCTQ7tPuXA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.3.tgz",
+            "integrity": "sha512-IOXOIm9WaK7plL2gMhsWJd+l2bfrhfilv0uPTptoRoSb2p09RghhQQp9YY6ZJhk/kqmeRt6siRdMSLLwzuT0KQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.3.tgz",
+            "integrity": "sha512-uTgCwsvQ5+vCQnqM//EfDSuomo2LhdWhFPS8VL8xKf+PKTCrcT/2kPPoWMTs22aB63MLdGMJiE3f1PHvCDmUOw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.3.tgz",
+            "integrity": "sha512-vNAkR17Ub2MgEud2Wag/OE4HTSI6zlb291UYzHez/psiKarp0J8PKGDnAhMBcHFoOHMXHfExzmjMojJNbAStrQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.3.tgz",
+            "integrity": "sha512-W8H9jlGiSBomkgmouaRoTXo49j4w4Kfbl6I1bIdO/vT0+0u4f20ko3ELzV3hPI6XV6JNBVX+8BC+ajHkvffIJA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.3.tgz",
+            "integrity": "sha512-EjEomwyLSCg8Ag3LDILIqYCZAq/y3diJ04PnqGRgq8/4O3VNlXyMd54j/saShaN4h5o5mivOjAzmU6C3X4v0xw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.3.tgz",
+            "integrity": "sha512-WGiE/GgbsEwR33++5rzjiYsKyHywE8QSZPF7Rfx9EBfK3Qn3xyR6IjyCr5Uk38Kg8fG4/2phN7sXp4NPWd3fcw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.3.tgz",
+            "integrity": "sha512-xRxC0jaJWDLYvcUvjQmHCJSfMrgmUuvsoXgDeU/wTorQ1ngDdUBuFtgY3W1Pc5sprGAvZBtWdJX7RPg/iZZUqA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -336,6 +705,44 @@
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.3.tgz",
+            "integrity": "sha512-Kgq0/ZsAPzKrbOjCQcjoSmPoWhlcVnGAUo7jvaLHoxW1Drto0KGkR1xBNg2Cp43b9ImvxmPEJZ9xkfcnqPsfBw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.21.3",
+                "@esbuild/android-arm": "0.21.3",
+                "@esbuild/android-arm64": "0.21.3",
+                "@esbuild/android-x64": "0.21.3",
+                "@esbuild/darwin-arm64": "0.21.3",
+                "@esbuild/darwin-x64": "0.21.3",
+                "@esbuild/freebsd-arm64": "0.21.3",
+                "@esbuild/freebsd-x64": "0.21.3",
+                "@esbuild/linux-arm": "0.21.3",
+                "@esbuild/linux-arm64": "0.21.3",
+                "@esbuild/linux-ia32": "0.21.3",
+                "@esbuild/linux-loong64": "0.21.3",
+                "@esbuild/linux-mips64el": "0.21.3",
+                "@esbuild/linux-ppc64": "0.21.3",
+                "@esbuild/linux-riscv64": "0.21.3",
+                "@esbuild/linux-s390x": "0.21.3",
+                "@esbuild/linux-x64": "0.21.3",
+                "@esbuild/netbsd-x64": "0.21.3",
+                "@esbuild/openbsd-x64": "0.21.3",
+                "@esbuild/sunos-x64": "0.21.3",
+                "@esbuild/win32-arm64": "0.21.3",
+                "@esbuild/win32-ia32": "0.21.3",
+                "@esbuild/win32-x64": "0.21.3"
             }
         },
         "node_modules/escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "activationEvents": [
         "onStartupFinished"
     ],
-    "main": "./src/main",
+    "main": "./dist/main.cjs",
     "contributes": {
         "commands": [
             {
@@ -425,6 +425,7 @@
         }
     },
     "scripts": {
+        "vscode:prepublish": "node ./scripts/build.mjs",
         "lint": "eslint \"./src/**/*.js\"",
         "lint:fix": "npm run lint -- --fix"
     },
@@ -433,6 +434,7 @@
         "jsonc": "^2.0.0"
     },
     "devDependencies": {
+        "esbuild": "^0.21.3",
         "eslint": "^8.51.0"
     }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,17 @@
+import esbuild from 'esbuild';
+import fs from 'node:fs';
+
+// Clear out any previously built files that no longer exist
+if (fs.existsSync('dist')) {
+    fs.rmSync('dist', { recursive: true });
+}
+
+esbuild.build({
+    entryPoints: ['src/main.js'],
+    outfile: 'dist/main.cjs',
+    format: 'cjs',
+    platform: 'node',
+    bundle: true,
+    sourcemap: true,
+    external: ['vscode'],
+});

--- a/src/iqgeo-jsdoc.js
+++ b/src/iqgeo-jsdoc.js
@@ -1,7 +1,7 @@
-const vscode = require('vscode'); // eslint-disable-line
-const Utils = require('./utils');
+import vscode from 'vscode'; // eslint-disable-line
+import Utils from './utils';
 
-class IQGeoJSDoc {
+export class IQGeoJSDoc {
     constructor(iqgeoVSCode, context) {
         this.iqgeoVSCode = iqgeoVSCode;
 
@@ -90,7 +90,7 @@ class IQGeoJSDoc {
     _getParamsForSymbol(sym, fileLines) {
         const symLine = sym.location.range.start.line;
         const length = Math.min(symLine + 16, fileLines.length);
-        const paramReg = /(?:\((.*?)\)\s+(?:\{|=>)|(\w+)\s*=>)/
+        const paramReg = /(?:\((.*?)\)\s+(?:\{|=>)|(\w+)\s*=>)/;
         const paramNames = [];
 
         const addParams = (str, prefix = '') => {
@@ -131,5 +131,3 @@ class IQGeoJSDoc {
         return paramNames;
     }
 }
-
-module.exports = IQGeoJSDoc;

--- a/src/iqgeo-layout.js
+++ b/src/iqgeo-layout.js
@@ -1,4 +1,4 @@
-const vscode = require('vscode'); // eslint-disable-line
+import vscode from 'vscode'; // eslint-disable-line
 
 const LAYOUT_CONFIG = [
     {
@@ -68,15 +68,15 @@ const LAYOUT_CONFIG = [
         name: 'editorGroup',
         commands: [
             'workbench.action.focusActiveEditorGroup',
-            'workbench.action.toggleMaximizeEditorGroup'
+            'workbench.action.toggleMaximizeEditorGroup',
         ],
-    }
+    },
 ];
 
 /**
  * Provide workspace layout commands for the IQGeo extension.
  */
-class IQGeoLayout {
+export class IQGeoLayout {
     constructor(context) {
         if (vscode.workspace.getConfiguration('iqgeo-utils-vscode').enableLayouts) {
             this._addLayouts(context);
@@ -84,7 +84,7 @@ class IQGeoLayout {
 
         context.subscriptions.push(
             vscode.commands.registerCommand('iqgeo.toggleTerminalFocus', async (args) => {
-                await this._toggleTerminalFocus(args.editorFocus)
+                await this._toggleTerminalFocus(args.editorFocus);
             })
         );
     }
@@ -116,5 +116,3 @@ class IQGeoLayout {
         }
     }
 }
-
-module.exports = IQGeoLayout;

--- a/src/iqgeo-linter.js
+++ b/src/iqgeo-linter.js
@@ -1,5 +1,5 @@
-const vscode = require('vscode'); // eslint-disable-line
-const Utils = require('./utils');
+import vscode from 'vscode'; // eslint-disable-line
+import Utils from './utils';
 
 const PROTECTED_CALL_REG = /(\w+)(?<!this)\.(_\w+)\(?/g;
 const METHOD_CALL_REG = /(\w+(?:\(.*?\))?)\.(\w+)\(/;
@@ -109,7 +109,7 @@ const IGNORE_METHOD_NAMES = [
  * - Subclassed protected methods without call to super
  * - Method calls that can't be resolved
  */
-class IQGeoLinter {
+export class IQGeoLinter {
     constructor(iqgeoVSCode) {
         this.iqgeoVSCode = iqgeoVSCode;
 
@@ -354,7 +354,7 @@ class IQGeoLinter {
                 ) {
                     let found = false;
 
-                    for (const [className, classData] of this.iqgeoVSCode.allClasses()) {
+                    for (const [, classData] of this.iqgeoVSCode.allClasses()) {
                         const methods = classData.methods;
                         if (methods[`${methodName}()`]) {
                             found = true;
@@ -458,5 +458,3 @@ class IQGeoLinter {
         }
     }
 }
-
-module.exports = IQGeoLinter;

--- a/src/iqgeo-project-update.js
+++ b/src/iqgeo-project-update.js
@@ -1,7 +1,7 @@
-const vscode = require('vscode'); // eslint-disable-line
-const fs = require('fs');
-const path = require('path');
-const jsonc = require('jsonc');
+import vscode from 'vscode'; // eslint-disable-line
+import fs from 'fs';
+import path from 'path';
+import jsonc from 'jsonc';
 
 const aptGetMappingsBuild = {
     memcached: ['libmemcached-dev'],
@@ -131,7 +131,7 @@ const fileModifications = {
  * Updates a IQGeo project.
  * Project structure should as per https://github.com/IQGeo/utils-project-template with a .iqgeorc.jsonc configuration file
  */
-class IQGeoProjectUpdate {
+export class IQGeoProjectUpdate {
     constructor(context) {
         context.subscriptions.push(
             vscode.commands.registerCommand('iqgeo.updateProject', () => this.update())
@@ -284,5 +284,3 @@ function replaceFetchPipPackages(optionalDeps = [], content) {
     );
     return content;
 }
-
-module.exports = IQGeoProjectUpdate;

--- a/src/iqgeo-vscode.js
+++ b/src/iqgeo-vscode.js
@@ -1,14 +1,14 @@
-const vscode = require('vscode'); // eslint-disable-line
-const fs = require('fs');
-const path = require('path');
-const find = require('findit');
-const IQGeoSearch = require('./search/iqgeo-search');
-const IQGeoJSSearch = require('./search/iqgeo-js-search');
-const IQGeoPythonSearch = require('./search/iqgeo-python-search');
-const IQGeoLinter = require('./iqgeo-linter');
-const IQGeoJSDoc = require('./iqgeo-jsdoc');
-const IQGeoWatch = require('./iqgeo-watch');
-const Utils = require('./utils');
+import vscode from 'vscode'; // eslint-disable-line
+import fs from 'fs';
+import path from 'path';
+import find from 'findit';
+import { IQGeoSearch } from './search/iqgeo-search';
+import { IQGeoJSSearch } from './search/iqgeo-js-search';
+import { IQGeoPythonSearch } from './search/iqgeo-python-search';
+import { IQGeoLinter } from './iqgeo-linter';
+import { IQGeoJSDoc } from './iqgeo-jsdoc';
+import { IQGeoWatch } from './iqgeo-watch';
+import Utils from './utils';
 
 const PROTOTYPE_CALL_REG = /(\w+)\.prototype\.(\w+)\.(call|apply)\s*\(/;
 const IMPORT_REG = /^\s*import\s+(\w*),?\s*{?([\w\s,]*)}?\s*from\s+['"](.*?)['"];?/;
@@ -26,7 +26,7 @@ const DEBUG = false;
  * - Definitions for JavaScript and Python
  * - Linting for JavaScript APIs
  */
-class IQGeoVSCode {
+export class IQGeoVSCode {
     constructor(context) {
         this.iqgeoSearch = new IQGeoSearch(this, context);
         this.linter = new IQGeoLinter(this);
@@ -1215,7 +1215,7 @@ class IQGeoVSCode {
     }
 
     _isTestFile(fileName) {
-        return /[\/]tests?[\/]/.test(fileName);
+        return /[/]tests?[/]/.test(fileName);
     }
 
     isWorkspaceFile(fileName) {
@@ -1249,5 +1249,3 @@ class IQGeoVSCode {
         );
     }
 }
-
-module.exports = IQGeoVSCode;

--- a/src/iqgeo-watch.js
+++ b/src/iqgeo-watch.js
@@ -1,7 +1,7 @@
-const vscode = require('vscode'); // eslint-disable-line
-const fs = require('fs');
-const path = require('path');
-const Utils = require('./utils');
+import vscode from 'vscode'; // eslint-disable-line
+import fs from 'fs';
+import path from 'path';
+import Utils from './utils';
 
 const CLIENT_DEBUG_TYPES = [
     'chrome',
@@ -14,7 +14,7 @@ const CLIENT_DEBUG_TYPES = [
 /**
  * The IQGeoWatch class is responsible for starting the webpack watch and restarting the client debug session when a file is saved.
  */
-class IQGeoWatch {
+export class IQGeoWatch {
     constructor(iqgeoVSCode, context) {
         this.iqgeoVSCode = iqgeoVSCode;
 
@@ -129,5 +129,3 @@ class IQGeoWatch {
         return !!this.pythonTerminal;
     }
 }
-
-module.exports = IQGeoWatch;

--- a/src/main.js
+++ b/src/main.js
@@ -1,21 +1,16 @@
-const IQGeoVSCode = require("./iqgeo-vscode");
-const IQGeoLayout = require("./iqgeo-layout");
-const IQGeoProjectUpdate = require('./iqgeo-project-update');
+import { IQGeoVSCode } from './iqgeo-vscode';
+import { IQGeoLayout } from './iqgeo-layout';
+import { IQGeoProjectUpdate } from './iqgeo-project-update';
 
 let iqgeoVSCode;
 
-function activate(context) {
+export function activate(context) {
     iqgeoVSCode = new IQGeoVSCode(context);
     new IQGeoLayout(context);
     new IQGeoProjectUpdate(context);
     iqgeoVSCode.onActivation();
 }
 
-function deactivate() {
+export function deactivate() {
     iqgeoVSCode.onDeactivation();
 }
-
-module.exports = {
-    activate,
-    deactivate
-};

--- a/src/search/iqgeo-js-search.js
+++ b/src/search/iqgeo-js-search.js
@@ -1,5 +1,5 @@
-const vscode = require('vscode'); // eslint-disable-line
-const Utils = require('../utils');
+import vscode from 'vscode'; // eslint-disable-line
+import Utils from '../utils';
 
 const EXTEND_REG = /(\w+)\.extend\s*\(\s*['"](\w+)['"]/;
 const EXTEND_MULTI_LINE_REG = /(\w+)\.extend\s*\(\s*$/;
@@ -14,7 +14,7 @@ const EXPORT_MIXIN_REG = /^export\s+(?:(?:default|const)\s+)*(\w+(Mixin)?)\s*=\s
 const CLASS_ASSIGN_REG = /(?:^|\s+)Object\.assign\(.*?(\w+)\.prototype,\s*(\w+)\)/;
 const PROPERTY_REG = /^\s*#?(\w+):/;
 const SETTER_OR_GETTER_REG = /^\s*(?:(?:set|get)\s+)(\w+)\s*\(/;
-const FUNCTION_REG = /^\s*(?:async\s+|static\s+|#)?\*?(\w+)\s*\(([\w,\s={}\[\]'"]|\.{3})*?\)\s*{/;
+const FUNCTION_REG = /^\s*(?:async\s+|static\s+|#)?\*?(\w+)\s*\(([\w,\s={}[\]'"]|\.{3})*?\)\s*{/;
 const FUNCTION_MULTI_LINE_REG = /^\s*(async\s*|static\s*|#)?\*?\w+\s*\(\s*$/;
 const CONST_FUNCTION_REG = /^const\s+(\w+)\s*=\s*(?:async\s+)?function\*?\s*\(/;
 const CONST_ARROW_FUNCTION_REG = /^const\s+(\w+)\s*=[^;]*?\s+=>\s+/;
@@ -30,7 +30,7 @@ const LITERAL_BEFORE_QUOTE_REG = /^[^'"]*`/;
 const INC_BRACKETS = /(?<!%)[{]/g;
 const DEC_BRACKETS = /(?<!%)[}]/g;
 
-class IQGeoJSSearch {
+export class IQGeoJSSearch {
     constructor(iqgeoVSCode) {
         this.iqgeoVSCode = iqgeoVSCode;
     }
@@ -438,5 +438,3 @@ class IQGeoJSSearch {
         return false;
     }
 }
-
-module.exports = IQGeoJSSearch;

--- a/src/search/iqgeo-python-search.js
+++ b/src/search/iqgeo-python-search.js
@@ -1,5 +1,5 @@
-const vscode = require('vscode'); // eslint-disable-line
-const Utils = require('../utils');
+import vscode from 'vscode'; // eslint-disable-line
+import Utils from '../utils';
 
 const PYTHON_CLASS_REG = /^\s*class\s+(\w+)(?:\(((?:[\w=]+,?\s*)*?)\))?:/;
 const PYTHON_DEF_REG = /^\s+def\s+(\w+)\(.*?\)(\s+->.*?)?:/;
@@ -7,7 +7,7 @@ const PYTHON_DEF_MULTI_LINE_REG = /^\s+def\s+(\w+)\(\s*$/;
 const EXPORT_PYTHON_DEF_REG = /^def\s+(\w+)\(.*?\)(\s+->.*?)?:/;
 const EXPORT_PYTHON_DEF_MULTI_LINE_REG = /^def\s+(\w+)\(\s*$/;
 
-class IQGeoPythonSearch {
+export class IQGeoPythonSearch {
     constructor(iqgeoVSCode) {
         this.iqgeoVSCode = iqgeoVSCode;
     }
@@ -132,5 +132,3 @@ class IQGeoPythonSearch {
         }
     }
 }
-
-module.exports = IQGeoPythonSearch;

--- a/src/search/iqgeo-search.js
+++ b/src/search/iqgeo-search.js
@@ -1,17 +1,17 @@
-const vscode = require('vscode'); // eslint-disable-line
-const fs = require('fs');
-const path = require('path');
-const Utils = require('../utils');
+import vscode from 'vscode'; // eslint-disable-line
+import fs from 'fs';
+import path from 'path';
+import Utils from '../utils';
 
 const LANGUAGE_MAP = {
-    'js': 'javascript',
-    'py': 'python',
-    'yml': 'yaml',
-    'md': 'markdown',
-    'txt': 'plaintext',
+    js: 'javascript',
+    py: 'python',
+    yml: 'yaml',
+    md: 'markdown',
+    txt: 'plaintext',
 };
 
-class IQGeoSearch {
+export class IQGeoSearch {
     constructor(iqgeoVSCode, context) {
         this.iqgeoVSCode = iqgeoVSCode;
 
@@ -365,9 +365,11 @@ class IQGeoSearch {
             this._fileIconConfig = null;
 
             const extName = vscode.workspace.getConfiguration('workbench').iconTheme;
-            let ext = vscode.extensions.all.find(ext => ext.id.endsWith(extName));
+            let ext = vscode.extensions.all.find((ext) => ext.id.endsWith(extName));
             if (!ext) {
-                ext = vscode.extensions.all.filter(ext => ext.isActive && ext.packageJSON.contributes.iconThemes)[0];
+                ext = vscode.extensions.all.filter(
+                    (ext) => ext.isActive && ext.packageJSON.contributes.iconThemes
+                )[0];
             }
 
             if (ext) {
@@ -386,7 +388,9 @@ class IQGeoSearch {
         if (!this._fileIconConfig) return;
 
         let key = path.basename(fileName);
-        let id = this._fileIconConfig.fileNames[key] ?? this._fileIconConfig.fileNames[key.toLowerCase()];
+        let id =
+            this._fileIconConfig.fileNames[key] ??
+            this._fileIconConfig.fileNames[key.toLowerCase()];
         if (!id) {
             const parts = key.split('.');
             key = parts.length > 2 ? parts.slice(-2).join('.') : parts.slice(-1)[0];
@@ -428,5 +432,3 @@ class IQGeoSearch {
         return fileName;
     }
 }
-
-module.exports = IQGeoSearch;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
-const vscode = require('vscode'); // eslint-disable-line
-const fs = require('fs');
+import vscode from 'vscode';
+import fs from 'fs';
 
 const INVALID_NAME_CHAR = /[^\w]/;
 
@@ -265,7 +265,7 @@ function wait(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-module.exports = {
+export default {
     getFileLines,
     getDocLines,
     removeStrings,


### PR DESCRIPTION
As part of [moving the project update tool to a separate NPM package](https://iqgeo.atlassian.net/browse/PLAT-9641?atlOrigin=eyJpIjoiMDI5NWFjNDFlNTc1NGVjM2IzN2JjNDVlMDE5MWZmODUiLCJwIjoiaiJ9), this extension needs to be written in ESM because we want [the product update package](https://github.com/IQGeo/utils-project-update) to use ESM. VSCode extensions can't be ESM at runtime because VSCode uses an old version of Electron that doesn't support it ([see this issue](https://github.com/microsoft/vscode/issues/130367)).

This PR adds a build step using [ESBuild](https://esbuild.github.io/) to transpile ESM to CJS.

VSCode docs on bundling: https://code.visualstudio.com/api/working-with-extensions/bundling-extension