### PR TITLE
projectUpdate tool: add pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ The extension provides the following features:
 5. Command to create JSDoc comment for a function or class.<br>
    Press Ctrl+Shift+D when the cursor is on the definition line to create a JSDoc comment populated with the parameters. Any defaults will be included.
 
-6. Command to update an IQGeo project based on options in .iqgeorc.jsonc configuration file.<br>
-   "IQGeo Update Project from .iqgeorc.jsonc" is available from the command palette (Ctrl+Cmd+P or Ctrl+Shift+P) or from the right click menu when editing .iqgeorc.jsonc<br>
-   See https://github.com/IQGeo/utils-project-template for details.
+6. Command to update an IQGeo project based on options in `.iqgeorc.jsonc` configuration file.<br>
+   "IQGeo Update Project from .iqgeorc.jsonc" is available from the command palette (Ctrl+Cmd+P or Ctrl+Shift+P) or from the right click menu when editing `.iqgeorc.jsonc`.<br>
+   See [`utils-project-template`](https://github.com/IQGeo/utils-project-template) and [`utils-project-update`](https://github.com/IQGeo/utils-project-update#default-update) for details.
 
-7. File watch to restart Python or browser debug session when a Python or JavaScript file change respectively.<br>
+7. Command to pull and merge latest changes from [`utils-project-template`](https://github.com/IQGeo/utils-project-template) with existing project files.<br>
+   "IQGeo Pull and merge files from project-template" is available from the command palette (Ctrl+Cmd+P or Ctrl+Shift+P) or from the right click menu when editing `.iqgeorc.jsonc`.<br>
+   See [`utils-project-template`](https://github.com/IQGeo/utils-project-template) and [`utils-project-update`](https://github.com/IQGeo/utils-project-update#pull) for details.
+
+8. File watch to restart Python or browser debug session when a Python or JavaScript file change respectively.<br>
    This functionality is enabled when **iqgeo-utils-vscode.enableAutoRestart** is set to true.<br>
    The extension uses one terminal to restart the Python environment and another to run a Javascript file watch. A browser debug session (if active) will be restarted when a JavaScript file is saved.<br>
    The watch can be started using the command 'IQGeo Start Watch'.<br>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "findit": "^2.0.0",
-                "project-update": "github:IQGeo/utils-project-update#v0.3.0"
+                "project-update": "github:IQGeo/utils-project-update#v0.3.1"
             },
             "devDependencies": {
                 "esbuild": "^0.21.3",
@@ -1380,8 +1380,8 @@
             }
         },
         "node_modules/project-update": {
-            "version": "0.3.0",
-            "resolved": "git+ssh://git@github.com/IQGeo/utils-project-update.git#22c239222fd70f3d3d174aedcdbbb29230a66d48",
+            "version": "0.3.1",
+            "resolved": "git+ssh://git@github.com/IQGeo/utils-project-update.git#54dd89c72afa4c322f7528552f1e4284868740c0",
             "license": "ISC",
             "dependencies": {
                 "diff": "^5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "findit": "^2.0.0",
-                "project-update": "github:IQGeo/utils-project-update#v0.2.0"
+                "project-update": "github:IQGeo/utils-project-update#v0.3.0"
             },
             "devDependencies": {
                 "esbuild": "^0.21.3",
@@ -696,6 +696,14 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
+        "node_modules/diff": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
         "node_modules/doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -712,14 +720,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/error-ex": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dependencies": {
-                "is-arrayish": "^0.2.1"
-            }
         },
         "node_modules/esbuild": {
             "version": "0.21.4",
@@ -939,11 +939,6 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
-        "node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
-        },
         "node_modules/fastq": {
             "version": "1.17.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -1068,11 +1063,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-        },
         "node_modules/graphemer": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -1139,11 +1129,6 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
-        "node_modules/is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1206,11 +1191,6 @@
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true
         },
-        "node_modules/json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
-        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1223,21 +1203,10 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
-        "node_modules/jsonc": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jsonc/-/jsonc-2.0.0.tgz",
-            "integrity": "sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==",
-            "dependencies": {
-                "fast-safe-stringify": "^2.0.6",
-                "graceful-fs": "^4.1.15",
-                "mkdirp": "^0.5.1",
-                "parse-json": "^4.0.0",
-                "strip-bom": "^4.0.0",
-                "strip-json-comments": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
+        "node_modules/jsonc-parser": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+            "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
         },
         "node_modules/keyv": {
             "version": "4.5.4",
@@ -1292,25 +1261,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/minimist": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
             }
         },
         "node_modules/ms": {
@@ -1393,18 +1343,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-            "dependencies": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1442,11 +1380,12 @@
             }
         },
         "node_modules/project-update": {
-            "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/IQGeo/utils-project-update.git#7a1c14b4622e8bf9e65054ab25f105110c5b044b",
+            "version": "0.3.0",
+            "resolved": "git+ssh://git@github.com/IQGeo/utils-project-update.git#22c239222fd70f3d3d174aedcdbbb29230a66d48",
             "license": "ISC",
             "dependencies": {
-                "jsonc": "^2.0.0",
+                "diff": "^5.2.0",
+                "jsonc-parser": "^3.2.1",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -1596,18 +1535,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-bom": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             },

--- a/package.json
+++ b/package.json
@@ -450,7 +450,7 @@
     },
     "dependencies": {
         "findit": "^2.0.0",
-        "project-update": "github:IQGeo/utils-project-update#v0.3.0"
+        "project-update": "github:IQGeo/utils-project-update#v0.3.1"
     },
     "devDependencies": {
         "esbuild": "^0.21.3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,10 @@
                 "title": "IQGeo Update Project from .iqgeorc.jsonc"
             },
             {
+                "command": "iqgeo.pullTemplate",
+                "title": "IQGeo Pull and merge files from project-template"
+            },
+            {
                 "command": "iqgeo.startWatch",
                 "title": "IQGeo Start Watch"
             }

--- a/package.json
+++ b/package.json
@@ -450,7 +450,7 @@
     },
     "dependencies": {
         "findit": "^2.0.0",
-        "project-update": "github:IQGeo/utils-project-update#v0.2.0"
+        "project-update": "github:IQGeo/utils-project-update#v0.3.0"
     },
     "devDependencies": {
         "esbuild": "^0.21.3",

--- a/package.json
+++ b/package.json
@@ -334,6 +334,11 @@
                     "when": "resourceFilename == .iqgeorc.jsonc",
                     "command": "iqgeo.updateProject",
                     "group": "iqgeo"
+                },
+                {
+                    "when": "resourceFilename == .iqgeorc.jsonc",
+                    "command": "iqgeo.pullTemplate",
+                    "group": "iqgeo"
                 }
             ],
             "editor/title/context": [
@@ -341,12 +346,22 @@
                     "when": "resourceFilename == .iqgeorc.jsonc",
                     "command": "iqgeo.updateProject",
                     "group": "iqgeo"
+                },
+                {
+                    "when": "resourceFilename == .iqgeorc.jsonc",
+                    "command": "iqgeo.pullTemplate",
+                    "group": "iqgeo"
                 }
             ],
             "explorer/context": [
                 {
                     "when": "resourceFilename == .iqgeorc.jsonc",
                     "command": "iqgeo.updateProject",
+                    "group": "iqgeo"
+                },
+                {
+                    "when": "resourceFilename == .iqgeorc.jsonc",
+                    "command": "iqgeo.pullTemplate",
                     "group": "iqgeo"
                 }
             ]

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -14,4 +14,7 @@ esbuild.build({
     bundle: true,
     sourcemap: true,
     external: ['vscode'],
+    // TBR: this is a workaround until https://github.com/microsoft/node-jsonc-parser/pull/78 is merged.
+    // `project-update` relies on that package and will be bundled incorrectly otherwise
+    mainFields: ['module', 'main'],
 });

--- a/src/iqgeo-linter.js
+++ b/src/iqgeo-linter.js
@@ -1,4 +1,5 @@
 import vscode from 'vscode'; // eslint-disable-line
+import util from 'util';
 import Utils from './utils';
 
 const PROTECTED_CALL_REG = /(\w+)(?<!this)\.(_\w+)\(?/g;
@@ -117,21 +118,17 @@ export class IQGeoLinter {
 
         vscode.workspace.onDidOpenTextDocument((doc) => {
             if (doc.languageId === 'javascript') {
-                try {
-                    this._checkFile(doc);
-                } catch (error) {
-                    console.error(error);
-                }
+                this._checkFile(doc).catch((err) => {
+                    this.iqgeoVSCode.outputChannel.error(util.format(err));
+                });
             }
         });
 
         vscode.workspace.onDidSaveTextDocument((doc) => {
             if (doc.languageId === 'javascript') {
-                try {
-                    this._checkFile(doc);
-                } catch (error) {
-                    console.error(error);
-                }
+                this._checkFile(doc).catch((err) => {
+                    this.iqgeoVSCode.outputChannel.error(util.format(err));
+                });
             }
         });
 
@@ -449,11 +446,9 @@ export class IQGeoLinter {
     checkOpenFiles() {
         for (const doc of vscode.workspace.textDocuments) {
             if (doc.languageId === 'javascript') {
-                try {
-                    this._checkFile(doc);
-                } catch (error) {
-                    console.error(error);
-                }
+                this._checkFile(doc).catch((err) => {
+                    this.iqgeoVSCode.outputChannel.error(util.format(err));
+                });
             }
         }
     }

--- a/src/iqgeo-project-update.js
+++ b/src/iqgeo-project-update.js
@@ -1,7 +1,32 @@
+// @ts-check
 import vscode from 'vscode'; // eslint-disable-line
 import util from 'util';
 
 import { pull, update } from 'project-update';
+
+/**
+ * @param {(msg: string) => void} notificationCb
+ * @param {(msg: string) => void} outputCb
+ * @returns {ProgressHandler[keyof ProgressHandler]}
+ */
+function getProgressMethod(notificationCb, outputCb) {
+    return (level, info, moreDetails) => {
+        if (moreDetails) {
+            if (level === 1) {
+                notificationCb(`${info} ([details](command:iqgeo.showOutput))`);
+            }
+
+            outputCb(util.format(info));
+            outputCb(util.format(moreDetails));
+        } else {
+            if (level === 1) {
+                notificationCb(info);
+            }
+
+            outputCb(util.format(info));
+        }
+    };
+}
 
 /**
  * Updates a IQGeo project.
@@ -16,43 +41,14 @@ export class IQGeoProjectUpdate {
             vscode.commands.registerCommand('iqgeo.updateProject', () => this._update()),
             vscode.commands.registerCommand('iqgeo.pullTemplate', () => this._pull())
         );
+
+        /** @type {ProgressHandler} */
+        this._progressHandlers = {
+            log: getProgressMethod(vscode.window.showInformationMessage, outputChannel.info),
+            warn: getProgressMethod(vscode.window.showWarningMessage, outputChannel.warn),
+            error: getProgressMethod(vscode.window.showErrorMessage, outputChannel.error),
+        };
     }
-
-    /** @type {import('project-update').ProgressHandler} */
-    _progressHandlers = {
-        log: (level, info, moreDetails) => {
-            if (moreDetails) {
-                vscode.window.showInformationMessage(
-                    `${info} ([details](command:iqgeo.showOutput))`
-                );
-
-                this.outputChannel.info(util.format(info));
-                this.outputChannel.info(util.format(moreDetails));
-            } else {
-                vscode.window.showInformationMessage(info);
-            }
-        },
-        warn: (level, info, moreDetails) => {
-            if (moreDetails) {
-                vscode.window.showWarningMessage(`${info} ([details](command:iqgeo.showOutput))`);
-
-                this.outputChannel.warn(util.format(info));
-                this.outputChannel.warn(util.format(moreDetails));
-            } else {
-                vscode.window.showWarningMessage(info);
-            }
-        },
-        error: (level, info, moreDetails) => {
-            if (moreDetails) {
-                vscode.window.showErrorMessage(`${info} ([details](command:iqgeo.showOutput))`);
-
-                this.outputChannel.error(util.format(info));
-                this.outputChannel.error(util.format(moreDetails));
-            } else {
-                vscode.window.showErrorMessage(info);
-            }
-        },
-    };
 
     async _update() {
         const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -84,3 +80,7 @@ export class IQGeoProjectUpdate {
         );
     }
 }
+
+/**
+ * @typedef {import('project-update').ProgressHandler} ProgressHandler
+ */

--- a/src/iqgeo-project-update.js
+++ b/src/iqgeo-project-update.js
@@ -37,17 +37,17 @@ export class IQGeoProjectUpdate {
     constructor(context, outputChannel) {
         this.outputChannel = outputChannel;
 
-        context.subscriptions.push(
-            vscode.commands.registerCommand('iqgeo.updateProject', () => this._update()),
-            vscode.commands.registerCommand('iqgeo.pullTemplate', () => this._pull())
-        );
-
         /** @type {ProgressHandler} */
-        this._progressHandlers = {
+        this._progressHandler = {
             log: getProgressMethod(vscode.window.showInformationMessage, outputChannel.info),
             warn: getProgressMethod(vscode.window.showWarningMessage, outputChannel.warn),
             error: getProgressMethod(vscode.window.showErrorMessage, outputChannel.error),
         };
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand('iqgeo.updateProject', () => this._update()),
+            vscode.commands.registerCommand('iqgeo.pullTemplate', () => this._pull())
+        );
     }
 
     async _update() {
@@ -57,7 +57,7 @@ export class IQGeoProjectUpdate {
 
         update({
             root,
-            progress: this._progressHandlers,
+            progress: this._progressHandler,
         });
     }
 
@@ -74,7 +74,7 @@ export class IQGeoProjectUpdate {
             () => {
                 return pull({
                     out,
-                    progress: this._progressHandlers,
+                    progress: this._progressHandler,
                 });
             }
         );

--- a/src/iqgeo-project-update.js
+++ b/src/iqgeo-project-update.js
@@ -1,6 +1,6 @@
 import vscode from 'vscode'; // eslint-disable-line
 
-import { update } from 'project-update';
+import { pull, update } from 'project-update';
 
 /**
  * Updates a IQGeo project.
@@ -9,7 +9,8 @@ import { update } from 'project-update';
 export class IQGeoProjectUpdate {
     constructor(context) {
         context.subscriptions.push(
-            vscode.commands.registerCommand('iqgeo.updateProject', () => this._update())
+            vscode.commands.registerCommand('iqgeo.updateProject', () => this._update()),
+            vscode.commands.registerCommand('iqgeo.pullTemplate', () => this._pull())
         );
     }
 
@@ -21,6 +22,22 @@ export class IQGeoProjectUpdate {
         update({
             root,
             progress: {
+                log: (level, info) => vscode.window.showInformationMessage(info),
+                warn: (level, info) => vscode.window.showWarningMessage(info),
+                error: (level, info) => vscode.window.showErrorMessage(info),
+            },
+        });
+    }
+
+    async _pull() {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders) return;
+        const out = workspaceFolders[0].uri.fsPath;
+
+        pull({
+            out,
+            progress: {
+                // TODO: handle different log levels?
                 log: (level, info) => vscode.window.showInformationMessage(info),
                 warn: (level, info) => vscode.window.showWarningMessage(info),
                 error: (level, info) => vscode.window.showErrorMessage(info),

--- a/src/iqgeo-project-update.js
+++ b/src/iqgeo-project-update.js
@@ -1,4 +1,5 @@
 import vscode from 'vscode'; // eslint-disable-line
+import util from 'util';
 
 import { pull, update } from 'project-update';
 
@@ -7,7 +8,7 @@ import { pull, update } from 'project-update';
  * Project structure should as per https://github.com/IQGeo/utils-project-template with a .iqgeorc.jsonc configuration file
  */
 export class IQGeoProjectUpdate {
-    /** @param {vscode.OutputChannel} outputChannel */
+    /** @param {vscode.LogOutputChannel} outputChannel */
     constructor(context, outputChannel) {
         this.outputChannel = outputChannel;
 
@@ -17,6 +18,7 @@ export class IQGeoProjectUpdate {
         );
     }
 
+    /** @type {import('project-update').ProgressHandler} */
     _progressHandlers = {
         log: (level, info, moreDetails) => {
             if (moreDetails) {
@@ -24,7 +26,8 @@ export class IQGeoProjectUpdate {
                     `${info} ([details](command:iqgeo.showOutput))`
                 );
 
-                this.outputChannel.appendLine(moreDetails);
+                this.outputChannel.info(util.format(info));
+                this.outputChannel.info(util.format(moreDetails));
             } else {
                 vscode.window.showInformationMessage(info);
             }
@@ -33,7 +36,8 @@ export class IQGeoProjectUpdate {
             if (moreDetails) {
                 vscode.window.showWarningMessage(`${info} ([details](command:iqgeo.showOutput))`);
 
-                this.outputChannel.appendLine(moreDetails);
+                this.outputChannel.warn(util.format(info));
+                this.outputChannel.warn(util.format(moreDetails));
             } else {
                 vscode.window.showWarningMessage(info);
             }
@@ -42,7 +46,8 @@ export class IQGeoProjectUpdate {
             if (moreDetails) {
                 vscode.window.showErrorMessage(`${info} ([details](command:iqgeo.showOutput))`);
 
-                this.outputChannel.appendLine(moreDetails);
+                this.outputChannel.error(util.format(info));
+                this.outputChannel.error(util.format(moreDetails));
             } else {
                 vscode.window.showErrorMessage(info);
             }

--- a/src/iqgeo-project-update.js
+++ b/src/iqgeo-project-update.js
@@ -4,8 +4,10 @@ import util from 'util';
 
 import { pull, update } from 'project-update';
 
+import utils from './utils';
+
 /**
- * @param {(msg: string) => void} notificationCb
+ * @param {(msg: string, items?: string) => Thenable<string | undefined>} notificationCb
  * @param {(msg: string) => void} outputCb
  * @returns {ProgressHandler[keyof ProgressHandler]}
  */
@@ -13,7 +15,7 @@ function getProgressMethod(notificationCb, outputCb) {
     return (level, info, moreDetails) => {
         if (moreDetails) {
             if (level === 1) {
-                notificationCb(`${info} ([details](command:iqgeo.showOutput))`);
+                utils.showMessageWithDetails(notificationCb, info);
             }
 
             outputCb(util.format(info));

--- a/src/iqgeo-project-update.js
+++ b/src/iqgeo-project-update.js
@@ -35,8 +35,6 @@ function getProgressMethod(notificationCb, outputCb) {
 export class IQGeoProjectUpdate {
     /** @param {vscode.LogOutputChannel} outputChannel */
     constructor(context, outputChannel) {
-        this.outputChannel = outputChannel;
-
         /** @type {ProgressHandler} */
         this._progressHandler = {
             log: getProgressMethod(vscode.window.showInformationMessage, outputChannel.info),

--- a/src/iqgeo-vscode.js
+++ b/src/iqgeo-vscode.js
@@ -943,7 +943,7 @@ export class IQGeoVSCode {
                     this.clearDataForFile(doc.fileName);
                     config.searchEngine.updateClasses(doc.fileName, fileLines);
                 } catch (error) {
-                    console.error(error);
+                    this.outputChannel.error(util.format(error));
                 }
                 break;
             }
@@ -983,7 +983,7 @@ export class IQGeoVSCode {
             if (searchSummary) {
                 this._showSearchSummary(summary);
             } else {
-                console.log(summary);
+                this.outputChannel.info(util.format(summary));
             }
         }
     }

--- a/src/iqgeo-vscode.js
+++ b/src/iqgeo-vscode.js
@@ -1,6 +1,7 @@
 import vscode from 'vscode'; // eslint-disable-line
 import fs from 'fs';
 import path from 'path';
+import util from 'util';
 import find from 'findit';
 import { IQGeoSearch } from './search/iqgeo-search';
 import { IQGeoJSSearch } from './search/iqgeo-js-search';
@@ -27,6 +28,10 @@ const DEBUG = false;
  * - Linting for JavaScript APIs
  */
 export class IQGeoVSCode {
+    /**
+     * @param {vscode.ExtensionContext} context
+     * @param {vscode.LogOutputChannel} outputChannel
+     */
     constructor(context, outputChannel) {
         this.iqgeoSearch = new IQGeoSearch(this, context);
         this.linter = new IQGeoLinter(this);
@@ -1026,7 +1031,7 @@ export class IQGeoVSCode {
             esClasses: summary.esClasses,
         };
 
-        this.outputChannel.appendLine(JSON.stringify(info, null, 2));
+        this.outputChannel.info(util.format(info));
         this.outputChannel.show(true);
     }
 

--- a/src/iqgeo-vscode.js
+++ b/src/iqgeo-vscode.js
@@ -27,11 +27,12 @@ const DEBUG = false;
  * - Linting for JavaScript APIs
  */
 export class IQGeoVSCode {
-    constructor(context) {
+    constructor(context, outputChannel) {
         this.iqgeoSearch = new IQGeoSearch(this, context);
         this.linter = new IQGeoLinter(this);
         this.iqgeoJSDoc = new IQGeoJSDoc(this, context);
         this.watchManager = new IQGeoWatch(this, context);
+        this.outputChannel = outputChannel;
 
         this.symbols = {};
         this.classes = new Map();
@@ -1025,9 +1026,6 @@ export class IQGeoVSCode {
             esClasses: summary.esClasses,
         };
 
-        if (!this.outputChannel) {
-            this.outputChannel = vscode.window.createOutputChannel('IQGeo VSCode');
-        }
         this.outputChannel.appendLine(JSON.stringify(info, null, 2));
         this.outputChannel.show(true);
     }

--- a/src/main.js
+++ b/src/main.js
@@ -7,10 +7,10 @@ import { IQGeoProjectUpdate } from './iqgeo-project-update';
 let iqgeoVSCode;
 
 export function activate(context) {
-    const outputChannel = vscode.window.createOutputChannel('IQGeo');
+    const outputChannel = vscode.window.createOutputChannel('IQGeo', { log: true });
 
     vscode.commands.registerCommand('iqgeo.showOutput', () => {
-        this.outputChannel.show();
+        outputChannel.show(true);
     });
 
     iqgeoVSCode = new IQGeoVSCode(context, outputChannel);

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+import vscode from 'vscode';
+
 import { IQGeoVSCode } from './iqgeo-vscode';
 import { IQGeoLayout } from './iqgeo-layout';
 import { IQGeoProjectUpdate } from './iqgeo-project-update';
@@ -5,9 +7,16 @@ import { IQGeoProjectUpdate } from './iqgeo-project-update';
 let iqgeoVSCode;
 
 export function activate(context) {
-    iqgeoVSCode = new IQGeoVSCode(context);
+    const outputChannel = vscode.window.createOutputChannel('IQGeo');
+
+    vscode.commands.registerCommand('iqgeo.showOutput', () => {
+        this.outputChannel.show();
+    });
+
+    iqgeoVSCode = new IQGeoVSCode(context, outputChannel);
     new IQGeoLayout(context);
-    new IQGeoProjectUpdate(context);
+    new IQGeoProjectUpdate(context, outputChannel);
+
     iqgeoVSCode.onActivation();
 }
 

--- a/src/search/iqgeo-js-search.js
+++ b/src/search/iqgeo-js-search.js
@@ -166,7 +166,7 @@ export class IQGeoJSSearch {
             }
         }
 
-        if (this.iqgeoVSCode.DEBUG) {
+        if (this.iqgeoVSCode.debug) {
             if (!classFound && symbolCount === 0) {
                 console.log('No class or symbols found in', fileName);
             } else if (!classFound) {

--- a/src/search/iqgeo-search.js
+++ b/src/search/iqgeo-search.js
@@ -1,6 +1,7 @@
 import vscode from 'vscode'; // eslint-disable-line
 import fs from 'fs';
 import path from 'path';
+import util from 'util';
 import Utils from '../utils';
 
 const LANGUAGE_MAP = {
@@ -379,7 +380,7 @@ export class IQGeoSearch {
                     this._fileIconConfig = JSON.parse(fs.readFileSync(configPath).toString());
                     this._fileIconConfig._configPath = path.dirname(configPath);
                 } catch (e) {
-                    console.log(e);
+                    this.iqgeoVSCode.outputChannel.error(util.format(e));
                     return;
                 }
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,6 +49,28 @@ function getDocLines(doc) {
     return lines;
 }
 
+/**
+ * Shows a VSCode message with a 'Show Details' button that will open the output channel when clicked.
+ *
+ * @param {"info" | "warn" | "error" | ((msg: string) => void)} levelOrFn
+ * @param {string} message
+ */
+async function showMessageWithDetails(levelOrFn, message) {
+    const showMessageMap = {
+        info: vscode.window.showInformationMessage,
+        warn: vscode.window.showWarningMessage,
+        error: vscode.window.showErrorMessage,
+    };
+
+    const showMessageFn = typeof levelOrFn === 'string' ? showMessageMap[levelOrFn] : levelOrFn;
+
+    const clickedItem = await showMessageFn(message, 'Show Details');
+
+    if (clickedItem === 'Show Details') {
+        vscode.commands.executeCommand('iqgeo.showOutput');
+    }
+}
+
 function removeStrings(str) {
     if (!/['"]/.test(str)) return str;
 
@@ -268,6 +290,7 @@ function wait(ms) {
 export default {
     getFileLines,
     getDocLines,
+    showMessageWithDetails,
     removeStrings,
     removeLiterals,
     removeComments,


### PR DESCRIPTION
This PR adds support for the new `pull` command from [`utils-project-update`](https://github.com/IQGeo/utils-project-update#pull), and refines how we log to the output channel.

## Changes

- Update README
- Add pull command and context menu options
- ESBuild workaround for `project-update` dependency bug
- Change `OutputChannel` to `LogOutputChannel` that's shared across classes
- Refactor some console logs to use the shared output channel
- Controlled handling of progress notifications and logs based on log level and `moreDetails`
- Progress notification for pull as it's asynchronous and can take a relatively long time
- Register `iqgeo.showOutput` command that can be triggered from notification links
- Fix a minor typo
- `showMessageWithDetails` util function