### PR TITLE
Bump project-update to 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "findit": "^2.0.0",
-                "project-update": "github:IQGeo/utils-project-update#v0.5.0"
+                "project-update": "github:IQGeo/utils-project-update#semver:^0.6.1"
             },
             "devDependencies": {
                 "@vscode/vsce": "^2.31.1",
@@ -3177,8 +3177,8 @@
             }
         },
         "node_modules/project-update": {
-            "version": "0.5.0",
-            "resolved": "git+ssh://git@github.com/IQGeo/utils-project-update.git#194f3c6e8168150ab939dcc02b54b36f36f6e78f",
+            "version": "0.6.1",
+            "resolved": "git+ssh://git@github.com/IQGeo/utils-project-update.git#517935e00159eef66a467d5cc603b5b9b31bb901",
             "license": "ISC",
             "dependencies": {
                 "diff": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -467,7 +467,7 @@
     },
     "dependencies": {
         "findit": "^2.0.0",
-        "project-update": "github:IQGeo/utils-project-update#v0.5.0"
+        "project-update": "github:IQGeo/utils-project-update#semver:^0.6.1"
     },
     "devDependencies": {
         "@vscode/vsce": "^2.31.1",


### PR DESCRIPTION
v0.6.1 includes some improvements and bug fixes. I've also changed the version specifier to use a `semver:` range.

List of changes: https://github.com/IQGeo/utils-project-update/blob/main/CHANGELOG.md