### PR TITLE
Fix search for duplicate class and method names.

### DIFF
--- a/src/iqgeo-vscode.js
+++ b/src/iqgeo-vscode.js
@@ -602,15 +602,16 @@ export class IQGeoVSCode {
 
         for (const [methodName, methodData] of Object.entries(classData.methods)) {
             const name = `${className}.${methodName}`;
+            const key = `${name}:${languageId}`;
 
             if (
-                !doneMethods.includes(name) &&
+                !doneMethods.includes(key) &&
                 this._matchString(methodName, methodString, matchOptions)
             ) {
                 const sym = this.getMethodSymbol(name, methodData);
 
                 symbols.push(sym);
-                doneMethods.push(name);
+                doneMethods.push(key);
 
                 if (symbols.length === max) return;
             }


### PR DESCRIPTION
Fixes search results where there are matching class and method names in different languages.
(e.g. in Platform DevDbCopperPairNetworkEngine.subPathsFor())